### PR TITLE
Add request information to NetworkError

### DIFF
--- a/src/NetworkError.js
+++ b/src/NetworkError.js
@@ -8,13 +8,24 @@
 class NetworkError extends Error {
   /**
    * @param {Error} exception - the original error
+   * @param {object} request - the request that was made with url etc.
    * @param  {...any} args - further arguments to pass to `Error`
    */
-  constructor(exception, ...args) {
-    super(...args);
+ constructor(exception, request, ...args) {
+   super(...args);	    super(...args);
 
-    this.internalException = exception;
-  }
+
+   this.internalRequest = request;
+   this.internalException = exception;	    this.internalException = exception;
+ }
+
+ /**
+  * The an object containing details of the request
+  * that was made.
+  */
+ get request() {
+   return this.internalRequest;
+ }
 
   /**
    * The original exception that was thrown.

--- a/src/request.js
+++ b/src/request.js
@@ -144,6 +144,7 @@ const request = async (urlArg, method = 'GET', body = undefined, opts = {}) => {
   } catch (error) {
     throw new NetworkError(
       error,
+      { url, ...sendableOptions },
       'A network error occurred. The network connection may have been disconnected, or the service may be down.',
     );
   }


### PR DESCRIPTION
APIErrors do not have this issue because you get the response
information and that contains the request information. However
NetworkError only contained a error message and had no information on
where it came from or what it related to. By passing in the request
parameters you are sending to the fetch request it makes it easy to do
say a network error occured connecting to x url etc. Also allow someone
to check and work with headers if there were any issues. Generally makes
debugging easier.