### PR TITLE
SKELE-295: add more information to errors

### DIFF
--- a/src/HttpError.js
+++ b/src/HttpError.js
@@ -39,6 +39,19 @@ class HttpError extends Error {
   }
 
   /**
+   * Get an "extra" object: a JSON-encodeable object that can be sent to Sentry
+   *
+   * @type {Object}
+   */
+  get extra() {
+    return {
+      body: this.body,
+      response: this.response,
+      statusCode: this.statusCode,
+    };
+  }
+
+  /**
    * The `fetch` `Response` object, which can be useful for low-level
    * operations. Note that the body stream will be locked.
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response}

--- a/src/NetworkError.js
+++ b/src/NetworkError.js
@@ -8,12 +8,22 @@
 class NetworkError extends Error {
   /**
    * @param {Error} exception - the original error
+   * @param {object} request - the request url along with any options passed along
    * @param  {...any} args - further arguments to pass to `Error`
    */
-  constructor(exception, ...args) {
+  constructor(exception, request, ...args) {
     super(...args);
 
+    this.internalRequest = request;
     this.internalException = exception;
+  }
+
+  /**
+   * Information about the failing request, like the URL and headers
+   * @type {object}
+   */
+  get request() {
+    return this.internalRequest;
   }
 
   /**

--- a/src/NetworkError.js
+++ b/src/NetworkError.js
@@ -27,6 +27,17 @@ class NetworkError extends Error {
   }
 
   /**
+   * Get an "extra" object: a JSON-encodeable object that can be sent to Sentry
+   *
+   * @type {Object}
+   */
+  get extra() {
+    return {
+      ...this.request,
+    };
+  }
+
+  /**
    * The original exception that was thrown.
    * @type {Error}
    */

--- a/src/request.js
+++ b/src/request.js
@@ -64,7 +64,7 @@ const createError = async (response) => {
   return new HttpError(
     response,
     body,
-    'The server responded with an HTTP error code.',
+    `The server responded with HTTP error code ${response.status}`,
   );
 };
 
@@ -144,6 +144,7 @@ const request = async (urlArg, method = 'GET', body = undefined, opts = {}) => {
   } catch (error) {
     throw new NetworkError(
       error,
+      { url, ...sendableOptions },
       'A network error occurred. The network connection may have been disconnected, or the service may be down.',
     );
   }


### PR DESCRIPTION
Add `extra` properties to `HttpError` and `NetworkError`, so we can capture more information in Sentry when our requests fail.