### PR TITLE
SKELE-298: Loosen engines.node field

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "regenerator-runtime": "^0.13.5"
   },
   "engines": {
-    "node": "^12.16.3",
+    "node": ">= 10.13.0",
     "npm": "^6.13.4",
     "yarn": "^1.21.1"
   },


### PR DESCRIPTION
The engines field was very strict: it required a 12.x version of Node in order to install.

For our internal projects, a strict engines field is desireable, but for published packages, it's best to allow a wide range of versions.