### PR TITLE
ci: Add docker auth to Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ defaults: &defaults
   docker:
     # the Docker image with Cypress dependencies
     - image: circleci/node:12
+      auth:
+        username: $DOCKERHUB_USER
+        password: $DOCKERHUB_PASSWORD
       environment:
         ## this enables colors in the output
         TERM: xterm
@@ -97,13 +100,21 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - install_packages
+      - install_packages:
+          context:
+            - hubblehq-docker
       - build:
+          context:
+            - hubblehq-docker
           requires:
             - install_packages
       - unitTests:
+          context:
+            - hubblehq-docker
           requires:
             - install_packages
       - linting:
+          context:
+            - hubblehq-docker
           requires:
             - install_packages


### PR DESCRIPTION
Docker will start rate limiting unauthenticated image pulls on November 1. This
change adds a Hubble docker account to our Circle configs, so that we don't get
throttled by Circle's pool of shared IP addresses.