### PR TITLE
Downgrade `isomorphic-unfetch` package from 4.0.2 to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "isomorphic-unfetch": "^4.0.2"
+    "isomorphic-unfetch": "4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3188,13 +3188,13 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
-isomorphic-unfetch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz#5fc04eeb1053b7b702278e2cf7a3f246cb3a9214"
-  integrity sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==
+isomorphic-unfetch@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-4.0.0.tgz#439422d68014e9355680e011ec05878c3a65672d"
+  integrity sha512-faQdcv4iQsZXTQIRWVVjfibY7CRxLBpvafqrc5ZgEPUXkDDiQu4nqXRtG5SuJUurW2XHM9uwPuna2r4Px2iNKA==
   dependencies:
     node-fetch "^3.2.0"
-    unfetch "^5.0.0"
+    unfetch "^4.2.0"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -5352,10 +5352,10 @@ underscore@~1.13.2:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
-unfetch@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-5.0.0.tgz#8a5b6e5779ebe4dde0049f7d7a81d4a1af99d142"
-  integrity sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
v4.0.1 introduced a `Module not found: Error: Can't resolve 'unfetch' in '/src/node_modules/isomorphic-unfetch'` error when trying to compile projects using our updated `@hubble/request` package.

This was due to it using v5.0.0 of the `unfetch` package as a dependency, which has an invalid path export in its package.json. There's a [PR for a fix submitted here](https://github.com/developit/unfetch/pull/164), but it's been sitting there since 10/02/2023, so there's no telling how long this may take to be updated on their end.

Therefore, downgrading to v4.0.0 of `isomorphic-unfetch` ensures it uses v4.2.0 of `unfetch`, which doesn't seem to have this problem.