### PR TITLE
fix: ensure dist is always built before publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,5 @@ Once your branch has been approved and merged, follow these steps from `main` to
 4. Bump the version — this will update `package.json` and automatically create a commit and tag: `yarn version`
 5. If the remote has received commits since the container was built, rebase on top of them: `git pull --rebase`
 6. Push the commit and tag to the repository: `git push && git push --tags`
-7. Build the distributable: `yarn build`
-8. Log in to npm using an account authorised to publish to the `@hubble` namespace: `yarn login`
-9. Publish to npm: `yarn publish`
+7. Log in to npm using an account authorised to publish to the `@hubble` namespace: `yarn login`
+8. Publish to npm: `yarn publish` (this will automatically build `dist` before publishing)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,6 +44,20 @@ steps:
         dev yarn test
     waitFor: ['Build image', 'Run linting']
 
+  - id: 'Verify package contents'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'sh'
+    args:
+      - -c
+      - |
+        docker compose \
+        -f docker-compose.yml \
+        --profile dev \
+        run \
+        --rm \
+        dev sh -c "yarn pack --filename /tmp/test-package.tgz && tar -tzf /tmp/test-package.tgz | grep -q 'dist/' && echo 'dist/ found in package' || (echo 'ERROR: dist/ missing from package' && exit 1)"
+    waitFor: ['Build image']
+
 substitutions:
   _SERVICE_NAME: request
   _BUILD_ID_SHORT: ${BUILD_ID:0:8}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "docs:publish": "yarn docs:build && gh-pages -d ./docs",
     "docs:start": "serve ./docs",
     "format": "prettier \"./src/**/*.{js,json}\" --write",
-    "lint": "yarn lint:eslint && yarn lint:format",
     "lint:eslint": "eslint .",
     "lint:format": "prettier \"./src/**/*.{js,json}\" --check",
+    "lint": "yarn lint:eslint && yarn lint:format",
+    "prepublishOnly": "yarn build",
     "start": "yarn build --watch",
     "test": "jest"
   },


### PR DESCRIPTION
- Add `prepublishOnly` script to package.json so `yarn build` runs automatically before `yarn publish`, preventing a publish without dist/
- Add CI step to verify package contents include dist/ using yarn pack
- Update README publishing instructions to remove redundant steps, add missing git pull --rebase, and clarify that yarn build is now handled automatically